### PR TITLE
Remove extraneous spaces from _oasis

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -82,7 +82,7 @@ Library lenses
     boomerang
   Modules:
     Prelude
-   
+
 Executable boomerang
   Path: boomerang
   MainIs: boomerang.ml


### PR DESCRIPTION
See commit 7b61509 for the detailed message motivating this. 
